### PR TITLE
Render skipping and some general render performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * `Game` creation will throw an error for option keys which are valid, but where the value is given as null or undefined. This is to prevent defaults from unknowingly being used.
 * Calling `setup()` on a `Game` is removed. Setup should now happen in the constructor, e.g., `new Game({ element: el, boardSize: 13 })`. Similarly for `Client`.
 * Dead stone marking is now faster in cases where there are many groups.
+* `playAt`, `pass` and `toggleDeadAt` now accept `{ render: false }` as an argument, which skips board rendering. This allows, e.g., playing N moves without rendering the board, then manually rendering once each has been played.
+* Some general improvements to board rendering.
 
 # v0.2.2
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Note that all functions which take two integer coordinates (`y` and `x`) are mea
 * `pass()`: passes for the current player.
 * `playAt(y, x)`: attempts to play a stone at `(y, x)` for the current player. If the move is illegal (because of ko, suicide, etc.), then nothing will happen. Returns `true` if the move is successful, otherwise `false`.
 * `isOver()`: returns `true` if the most recent 2 moves were passes, indicating the game is over, otherwise `false`.
-* `toggleDeadAt(y, x)`: sets the group of stones at `(y, x)` to be dead as part of marking territory. Only useful if `isOver()` is `true`.
+* `markDeadAt(y, x)`, `unmarkDeadAt(y, x)` and `toggleDeadAt(y, x)`: set the group of stones at `(y, x)` to dead or undead as part of marking territory. Only useful if the game is over.
 * `score()` returns scoring information, e.g., `{ black: 150, white: 130 }`. Only useful if `isOver()` is `true`, since proper scoring requires dead stone marking at the end of the game. Scoring is dependent on the scoring rules in use.
 * `undo()`: undo the most recent move.
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ Note that all functions which take two integer coordinates (`y` and `x`) are mea
 * `score()` returns scoring information, e.g., `{ black: 150, white: 130 }`. Only useful if `isOver()` is `true`, since proper scoring requires dead stone marking at the end of the game. Scoring is dependent on the scoring rules in use.
 * `undo()`: undo the most recent move.
 
+When rendering to a HTML board element, changing the game state will re-render the board. `pass`, `playAt`, `markDeadAt`, `unmarkDeadAt` and `toggleDeadAt` all support `{ render: false }` as an option, which will skip the board rendering step. To manually render the board with `render: false`, call `game.render()` explicitly.
+
 # Post-render callbacks
 
 There is a configurable callback, `postRender`, which is fired each time the board is rendered, e.g., after every move.

--- a/src/game.js
+++ b/src/game.js
@@ -187,7 +187,7 @@ Game.prototype = {
     return this.currentState().moveNumber;
   },
 
-  playAt: function(y, x) {
+  playAt: function(y, x, { render = true } = {}) {
     if (this.isIllegalAt(y, x)) {
       return false;
     }
@@ -201,12 +201,14 @@ Game.prototype = {
 
     this._moves.push(newState);
 
-    this.render();
+    if (render) {
+      this.render();
+    }
 
     return true;
   },
 
-  pass: function() {
+  pass: function({ render = true } = {}) {
     if (this.isOver()) {
       return false;
     }
@@ -214,7 +216,9 @@ Game.prototype = {
     const newState = this.currentState().playPass(this.currentPlayer());
     this._moves.push(newState);
 
-    this.render();
+    if (render) {
+      this.render();
+    }
 
     return true;
   },
@@ -230,7 +234,7 @@ Game.prototype = {
     return finalMove.pass && previousMove.pass;
   },
 
-  toggleDeadAt: function(y, x) {
+  toggleDeadAt: function(y, x, { render = true } = {}) {
     if (this.intersectionAt(y, x).isEmpty()) {
       return;
     }
@@ -245,7 +249,9 @@ Game.prototype = {
       }
     });
 
-    this.render();
+    if (render) {
+      this.render();
+    }
 
     return true;
   },

--- a/src/game.js
+++ b/src/game.js
@@ -234,18 +234,36 @@ Game.prototype = {
     return finalMove.pass && previousMove.pass;
   },
 
+  markDeadAt: function(y, x, { render = true } = {}) {
+    if (this._isDeadAt(y, x)) {
+      return true;
+    }
+
+    return this._setDeadStatus(y, x, true, { render });
+  },
+
+  unmarkDeadAt: function(y, x, { render = true } = {}) {
+    if (!this._isDeadAt(y, x)) {
+      return true;
+    }
+
+    return this._setDeadStatus(y, x, false, { render });
+  },
+
   toggleDeadAt: function(y, x, { render = true } = {}) {
+    return this._setDeadStatus(y, x, !this._isDeadAt(y, x), { render });
+  },
+
+  _setDeadStatus: function(y, x, markingDead, { render = true } = {}) {
     if (this.intersectionAt(y, x).isEmpty()) {
       return;
     }
 
-    const alreadyDead = this._isDeadAt(y, x);
-
     this.currentState().groupAt(y, x).forEach(intersection => {
-      if (alreadyDead) {
-        this._deadPoints = this._deadPoints.filter(dead => !(dead.y === intersection.y && dead.x === intersection.x));
-      } else {
+      if (markingDead) {
         this._deadPoints.push({ y: intersection.y, x: intersection.x });
+      } else {
+        this._deadPoints = this._deadPoints.filter(dead => !(dead.y === intersection.y && dead.x === intersection.x));
       }
     });
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -498,7 +498,7 @@ Renderer.prototype = {
       }
     }
 
-    if (territory) {
+    if (deadStones.length > 0 || territory.black.length > 0 || territory.white.length > 0) {
       this.renderTerritory(territory, deadStones);
     }
   },

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -136,10 +136,12 @@ Renderer.prototype = {
     });
     utils.appendElement(zoomContainer, specificRendererBoard);
 
-    renderer.computeSizing();
+    window.requestAnimationFrame(() => {
+      // we'll potentially be zooming on touch devices
+      zoomContainer.style.willChange = "transform";
 
-    // we'll potentially be zooming on touch devices
-    zoomContainer.style.willChange = "transform";
+      renderer.computeSizing();
+    });
 
     window.addEventListener("optimizedResize", () => {
       renderer.computeSizing();

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,6 +19,10 @@ export default {
     return `${prefix}-${str}`;
   },
 
+  clone: function(element) {
+    return element.cloneNode(true);
+  },
+
   createElement: function(elementName, options) {
     const element = document.createElement(elementName);
 
@@ -65,6 +69,10 @@ export default {
   },
 
   removeClass: function(el, className) {
+    if (!this.hasClass(el, className)) {
+      return;
+    }
+
     if (el.classList && el.classList.remove) {
       el.classList.remove(className);
       return;

--- a/test/game-scoring-test.js
+++ b/test/game-scoring-test.js
@@ -235,8 +235,8 @@ describe("scoring rules", function() {
     });
   });
 
-  describe("territory marking where two stones are alive on the board with nothing else", function() {
-    it("leads to no territory being marked", function() {
+  describe("territory marking with whole-board edge cases", function() {
+    it("scores two live stones of opposing color, with nothing else, as no points", function() {
       var game = new Game();
 
       game.playAt(0, 9); // b
@@ -246,6 +246,21 @@ describe("scoring rules", function() {
 
       expect(game.score().black).to.equal(0);
       expect(game.score().white).to.equal(0);
+    });
+
+    it("scores two dead stones of opposing color, with nothing else, as 1 point each under territory scoring", function() {
+      var game = new Game();
+
+      game.playAt(0, 9); // b
+      game.playAt(0, 10); // w
+      game.pass();
+      game.pass();
+
+      game.toggleDeadAt(0, 9);
+      game.toggleDeadAt(0, 10);
+
+      expect(game.score().black).to.equal(1);
+      expect(game.score().white).to.equal(1);
     });
   });
 });

--- a/test/game-test.js
+++ b/test/game-test.js
@@ -54,6 +54,38 @@ describe("Game", function() {
       game.playAt(5, 6);
       expect(game.intersectionAt(5, 6).value).to.equal("white");
     });
+
+    it("allows skipping a call to render", function() {
+      var game = new Game();
+
+      let calledRender = false;
+      game.render = function() {
+        calledRender = true;
+      }
+
+      game.playAt(5, 5, { render: false });
+      expect(calledRender).to.be.false;
+
+      game.playAt(5, 6);
+      expect(calledRender).to.be.true;
+    });
+  });
+
+  describe("pass", function() {
+    it("allows skipping a call to render", function() {
+      var game = new Game();
+
+      let calledRender = false;
+      game.render = function() {
+        calledRender = true;
+      }
+
+      game.pass({ render: false });
+      expect(calledRender).to.be.false;
+
+      game.pass();
+      expect(calledRender).to.be.true;
+    });
   });
 
   describe("intersectionAt", function() {
@@ -204,6 +236,27 @@ describe("Game", function() {
       game.toggleDeadAt(5, 6);
 
       expect(game.score()).to.deep.equal({ black: 0, white: 0 });
+    });
+
+    it("allows skipping a call to render", function() {
+      var game = new Game();
+
+      game.playAt(5, 5);
+      game.playAt(5, 6);
+
+      game.pass();
+      game.pass();
+
+      let calledRender = false;
+      game.render = function() {
+        calledRender = true;
+      }
+
+      game.toggleDeadAt(5, 5, { render: false });
+      expect(calledRender).to.be.false;
+
+      game.toggleDeadAt(5, 6);
+      expect(calledRender).to.be.true;
     });
   });
 

--- a/test/game-test.js
+++ b/test/game-test.js
@@ -217,6 +217,83 @@ describe("Game", function() {
     });
   });
 
+  describe("markDeadAt", function() {
+    it("allows skipping a call to render", function() {
+      var game = new Game();
+
+      game.playAt(5, 5);
+      game.playAt(5, 6);
+
+      game.pass();
+      game.pass();
+
+      let calledRender = false;
+      game.render = function() {
+        calledRender = true;
+      }
+
+      game.markDeadAt(5, 5, { render: false });
+      expect(calledRender).to.be.false;
+
+      game.markDeadAt(5, 6);
+      expect(calledRender).to.be.true;
+    });
+  });
+
+  describe("unmarkDeadAt", function() {
+    it("allows skipping a call to render", function() {
+      var game = new Game();
+
+      game.playAt(5, 5);
+      game.playAt(5, 6);
+
+      game.pass();
+      game.pass();
+
+      game.markDeadAt(5, 5);
+      game.markDeadAt(5, 6);
+
+      let calledRender = false;
+      game.render = function() {
+        calledRender = true;
+      }
+
+      game.unmarkDeadAt(5, 5, { render: false });
+      expect(calledRender).to.be.false;
+
+      game.unmarkDeadAt(5, 6);
+      expect(calledRender).to.be.true;
+    });
+  });
+
+  describe("dead stone marking with markDeadAt and unmarkDeadAt", function() {
+    it("mark stones as dead as part of the scoring calculation", function() {
+      var game = new Game();
+
+      game.playAt(5, 5);
+      game.playAt(5, 6);
+
+      game.pass();
+      game.pass();
+
+      expect(game.score()).to.deep.equal({ black: 0, white: 0 });
+
+      expect(game.markDeadAt(5, 6)).to.equal.true;
+      expect(game.score()).to.deep.equal({ black: 361, white: 0 });
+
+      // no change
+      expect(game.markDeadAt(5, 6)).to.equal.true;
+      expect(game.score()).to.deep.equal({ black: 361, white: 0 });
+
+      expect(game.unmarkDeadAt(5, 6)).to.equal.true;
+      expect(game.score()).to.deep.equal({ black: 0, white: 0 });
+
+      // no change
+      expect(game.unmarkDeadAt(5, 6)).to.equal.true;
+      expect(game.score()).to.deep.equal({ black: 0, white: 0 });
+    });
+  });
+
   describe("toggleDeadAt", function() {
     it("toggles stones dead as part of the scoring calculation", function() {
       var game = new Game();

--- a/test/renderer-test.js
+++ b/test/renderer-test.js
@@ -10,13 +10,13 @@ describe("renderer", function() {
   });
 
   ["svg", "dom"].forEach(renderer => {
-    [
-      "simple",
-      "positional-superko",
-      "situational-superko",
-      "natural-situational-superko"
-    ].forEach(koRule => {
-      describe(renderer, function() {
+    describe(renderer, function() {
+      [
+        "simple",
+        "positional-superko",
+        "situational-superko",
+        "natural-situational-superko"
+      ].forEach(koRule => {
         describe("ko markers", function() {
           it(`displays a ko marker for regular illegal ko moves under ${koRule}`, function() {
             var testBoardElement = document.querySelector("#test-board");
@@ -72,6 +72,27 @@ describe("renderer", function() {
             // 0, 1 _is_ allowed, so this isn't a ko
             expect(utils.hasClass(testBoardElement.querySelectorAll(".intersection")[1], "ko"), "expected the intersection to not be marked as a ko").to.be.false;
           });
+        });
+      });
+
+      describe("dead stone marking", function() {
+        it("marks two dead stones of opposing color, with nothing else, as dead", function() {
+          var testBoardElement = document.querySelector("#test-board");
+
+          var game = new Game({ element: testBoardElement, boardSize: 13, renderer: renderer });
+
+          game.playAt(0, 5); // b
+          game.playAt(0, 6); // w
+          game.pass();
+          game.pass();
+
+          expect(testBoardElement.querySelectorAll(".intersection.dead").length).to.equal(0);
+
+          game.toggleDeadAt(0, 5);
+          expect(testBoardElement.querySelectorAll(".intersection.dead").length).to.equal(1);
+
+          game.toggleDeadAt(0, 6);
+          expect(testBoardElement.querySelectorAll(".intersection.dead").length).to.equal(2);
         });
       });
     });


### PR DESCRIPTION
Playing, passing, and dead stone marking now support `{ render: false }` as an option to skip automatic board rendering. Moreover, `markDeadAt` and `unmarkDeadAt` are added as lower-level primitives alongside `toggleDeadAt`.

Bundled in here are some other performance improvements related to rendering.