### PR TITLE
Mark and unmark dead stones in bulk based on regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Dead stone marking is now faster in cases where there are many groups.
 * `playAt`, `pass` and `toggleDeadAt` now accept `{ render: false }` as an argument, which skips board rendering. This allows, e.g., playing N moves without rendering the board, then manually rendering once each has been played.
 * Some general improvements to board rendering.
+* Dead stone marking now happens in bulk based on regions.
 
 # v0.2.2
 

--- a/src/game.js
+++ b/src/game.js
@@ -255,11 +255,25 @@ Game.prototype = {
   },
 
   _setDeadStatus: function(y, x, markingDead, { render = true } = {}) {
-    if (this.intersectionAt(y, x).isEmpty()) {
+    const selectedIntersection = this.intersectionAt(y, x);
+
+    if (selectedIntersection.isEmpty()) {
       return;
     }
 
-    this.currentState().groupAt(y, x).forEach(intersection => {
+    const chosenDead = [];
+
+    const [candidates] = this.currentState().partitionTraverse(selectedIntersection, intersection => {
+      return intersection.isEmpty() || intersection.sameColorAs(selectedIntersection);
+    });
+
+    candidates.forEach(sameColorOrEmpty => {
+      if (!sameColorOrEmpty.isEmpty()) {
+        chosenDead.push(sameColorOrEmpty);
+      }
+    });
+
+    chosenDead.forEach(intersection => {
       if (markingDead) {
         this._deadPoints.push({ y: intersection.y, x: intersection.x });
       } else {

--- a/test/game-scoring-test.js
+++ b/test/game-scoring-test.js
@@ -97,7 +97,6 @@ describe("scoring rules", function() {
 
       // mark dead stones
       game.toggleDeadAt(1, 1);
-      game.toggleDeadAt(0, 2);
 
       // 2 dead stones are now ignored because they're marked dead
       expect(game.score().black).to.equal(10*19);
@@ -131,7 +130,6 @@ describe("scoring rules", function() {
 
       // mark dead stones
       game.toggleDeadAt(1, 1);
-      game.toggleDeadAt(0, 2);
 
       // 2 dead stones are now ignored because they're marked dead
       // plus 2 pass stones
@@ -191,7 +189,6 @@ describe("scoring rules", function() {
 
       // mark dead stones
       game.toggleDeadAt(1, 1);
-      game.toggleDeadAt(0, 2);
 
       expect(game.score().black).to.equal(9*19);
       // rectangle territory, 8*19

--- a/test/game-seki-detection-test.js
+++ b/test/game-seki-detection-test.js
@@ -615,7 +615,6 @@ describe("seki detection", function() {
 
     // mark both black stones dead
     game.toggleDeadAt(0, 1);
-    game.toggleDeadAt(1, 0);
 
     expect(game.score().black).to.equal(0);
 

--- a/test/game-test.js
+++ b/test/game-test.js
@@ -292,6 +292,57 @@ describe("Game", function() {
       expect(game.unmarkDeadAt(5, 6)).to.equal.true;
       expect(game.score()).to.deep.equal({ black: 0, white: 0 });
     });
+
+    it("sets dead stone state in bulk based on the region of the chosen stone", function() {
+      var game = new Game({ boardSize: 9 });
+
+      // ┌─┬─○─●─┬─┬─┬─┬─┐
+      // ○─○─○─●─┼─┼─┼─┼─┤
+      // ├─●─○─●─┼─┼─┼─┼─┤
+      // ●─○─○─●─┼─┼─┼─┼─┤
+      // ●─┼─○─●─┼─┼─┼─┼─┤
+      // ├─┼─○─●─┼─┼─┼─┼─┤
+      // ├─┼─○─●─┼─┼─┼─┼─┤
+      // ├─┼─○─●─┼─┼─┼─┼─┤
+      // └─┴─○─●─┴─┴─┴─┴─┘
+      game.playAt(0, 2);
+      game.playAt(0, 3);
+      game.playAt(1, 2);
+      game.playAt(1, 3);
+      game.playAt(2, 2);
+      game.playAt(2, 3);
+      game.playAt(3, 2);
+      game.playAt(3, 3);
+      game.playAt(4, 2);
+      game.playAt(4, 3);
+      game.playAt(5, 2);
+      game.playAt(5, 3);
+      game.playAt(6, 2);
+      game.playAt(6, 3);
+      game.playAt(7, 2);
+      game.playAt(7, 3);
+      game.playAt(8, 2);
+      game.playAt(8, 3);
+      game.playAt(1, 1);
+      game.playAt(4, 0);
+      game.playAt(1, 0);
+      game.playAt(2, 1);
+      game.playAt(3, 1);
+      game.playAt(3, 0);
+
+      game.pass();
+      game.pass();
+
+      expect(game.score().black).to.equal(0);
+
+      game.markDeadAt(2, 1);
+
+      expect(game.score().black).to.equal(18);
+
+      game.unmarkDeadAt(4, 0);
+
+      expect(game.score().black).to.equal(0);
+    });
   });
 
   describe("toggleDeadAt", function() {


### PR DESCRIPTION
Before, if two unconnected black stones were sitting in white's territory, you had to mark them as dead completely independently. Now, marking one stone as dead will automatically mark both stones as dead since they're both sitting in the same region.

### Before

![before](https://user-images.githubusercontent.com/342081/29148335-79cacad2-7d21-11e7-87cb-757c38e0e949.gif)

### After

![after](https://user-images.githubusercontent.com/342081/29148336-7cc570c0-7d21-11e7-945c-f19d02e131c4.gif)