### PR TITLE
Strip off hash part of URL for SVG background reference

### DIFF
--- a/src/svg-renderer.js
+++ b/src/svg-renderer.js
@@ -289,7 +289,8 @@ SVGRenderer.prototype.setIntersectionClasses = function(intersectionEl, intersec
     if (intersection.isEmpty()) {
       intersectionEl.querySelector(".stone").setAttribute("style", "");
     } else {
-      intersectionEl.querySelector(".stone").setAttribute("style", "fill: url(" + window.location + "#" + this[intersection.value + "GradientID"] + ")");
+      const base = window.location.href.split('#')[0];
+      intersectionEl.querySelector(".stone").setAttribute("style", "fill: url(" + base + "#" + this[intersection.value + "GradientID"] + ")");
     }
   }
 };


### PR DESCRIPTION
If the window.location contains a hash, the SVG background does not load. This fixes it.

I also had to modify the index.js for it to work for me, but that might not be appropriate for this PR. You could just use the modification to svg-renderer.js