### PR TITLE
Use browserify 8 at most to not break the build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-preset-es2015": "*",
     "babelify": "*",
     "body-parser": "^1.15.1",
-    "browserify": "*",
+    "browserify": "8",
     "chai": "^3.5.0",
     "clean-css-cli": "*",
     "eslint": "*",


### PR DESCRIPTION
The head of tenuki currently does not build.

There has been a few changes in browserify over the years, this will use a version that works with the old code to fix the breakage.