### PR TITLE
Update babel to use preset-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PATH  := node_modules/.bin:$(PATH)
-SHELL := /bin/bash
+SHELL := env PATH=$(PATH) /bin/bash
 
 name := tenuki
 
@@ -23,7 +23,7 @@ test: all
 
 build/$(name).js: build $(compiled_js)
 	cat copyright_header.txt \
-		<(browserify index.js --standalone $(name) -t [ babelify --presets [ es2015 ] ]) \
+		<(browserify index.js --standalone $(name) -t [ babelify --presets [ @babel/preset-env ] ]) \
 		> $@
 
 build/$(name).min.js: build/$(name).js
@@ -44,7 +44,7 @@ build/$(name).min.css: build/$(name).css
 lib/%.js: src/%.js
 	babel \
 		--source-maps \
-		--presets es2015 \
+		--presets @babel/preset-env \
 		--out-file $@ \
 		$<
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   },
   "homepage": "https://github.com/aprescott/tenuki#readme",
   "devDependencies": {
-    "babel-cli": "^6.7.7",
-    "babel-preset-es2015": "*",
+    "@babel/cli": "^7.19.3",
+    "@babel/core": "^7.20.5",
+    "@babel/preset-env": "^7.20.2",
     "babelify": "*",
     "body-parser": "^1.15.1",
     "browserify": "8",

--- a/src/client.js
+++ b/src/client.js
@@ -69,7 +69,7 @@ Client.prototype = {
     if (this._boardElement) {
       this._game = new Game(Object.assign({ element: this._boardElement }, gameOptions));
     } else {
-      this._game = new Game(...gameOptions);
+      this._game = new Game({...gameOptions});
     }
   },
 

--- a/test/highlight-test.js
+++ b/test/highlight-test.js
@@ -1,0 +1,24 @@
+var helpers = require("./helpers.js");
+var expect = require("chai").expect;
+var tenuki = require("../index.js");
+var Game = tenuki.Game;
+var utils = tenuki.utils;
+
+describe("Board highlights", function() {
+  beforeEach(function() {
+      helpers.generateNewTestBoard();
+    });
+  ["svg", "dom"].forEach(renderer => {
+  describe(`${renderer} renderer`, function() {
+        it("can highlight empty spaces", function() {
+          var testBoardElement = document.querySelector("#test-board");
+
+          var game = new Game({ element: testBoardElement, boardSize: 5, renderer: renderer });
+
+          expect(utils.hasClass(testBoardElement.querySelectorAll(".intersection")[1], "highlight")).to.be.false;
+          game.highlightAt(1,1);
+          expect(utils.hasClass(testBoardElement.querySelectorAll(".intersection")[1], "highlight")).to.be.true;
+        });
+      });
+  });
+});


### PR DESCRIPTION
Per https://babeljs.io/docs/en/env/ -- updated from preset-es2015 to preset-env. Also updated @babel-cli and @babel-core versions to be compatible. Updated shell in Makefile to set path variable, otherwise I was getting missing babel errors as I don't have babel installed globally.

This addresses comment https://github.com/aprescott/tenuki/issues/46#issuecomment-978352064